### PR TITLE
FIX: Janky layout animations

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 
 import { cn } from '@/lib/utils';
 import { useQueryString } from '@/hooks/queryString';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useObserveHeight } from '@/hooks/useObserveHeight';
 import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
@@ -26,13 +27,14 @@ export default function Home() {
   const { searchParams, createQueryString } = useQueryString();
   const { tests, runTests } = useTestStore();
   const { previouslyCheckedList, addPreviouslyChecked, updatePreviouslyChecked } = usePreviouslyCheckedStore();
-
+  const { isMobile, isTablet } = useMediaQuery();
   const [loading, setLoading] = useState(false);
 
   const [refreshIntervalTime, setRefreshIntervalTime] = useState<number>();
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
   const [secondsUntilNextRefresh, setSecondsUntilNextRefresh] = useState<number>(0);
   const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false);
+  const { ref, height } = useObserveHeight<HTMLFormElement>();
 
   const [resolvedAddresses, setResolvedAddresses] = useState<
     Record<
@@ -146,6 +148,7 @@ export default function Home() {
       <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col items-start gap-4 px-4 pb-14 lg:mt-10 lg:flex-row">
         <div className="w-full space-y-6 md:sticky lg:top-10 lg:max-w-md">
           <SearchForm
+            formRef={ref}
             advancedOptionsOpen={advancedOptionsOpen}
             setAdvancedOptionsOpen={setAdvancedOptionsOpen}
             onSubmit={(data) => {
@@ -162,7 +165,12 @@ export default function Home() {
         </div>
         <div className="w-full flex-1">
           <h2 className=" block font-heading text-3xl lg:hidden">Results</h2>
-          <div className={cn('space-y-2 lg:pb-0', advancedOptionsOpen ? 'pb-[400px]' : 'pb-24')}>
+          <div
+            style={{
+              paddingBottom: (isMobile || isTablet) && advancedOptionsOpen ? `${height}px` : '96px',
+            }}
+            className="space-y-2"
+          >
             {dnsServers.map((dnsServer) => {
               const result = resolvedAddresses[dnsServer.name];
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,9 @@ import { dnsServers } from '@/constants/dnsServers';
 import { RecordTypes, type RecordType } from '@/constants/recordType';
 import { usePreviouslyCheckedStore } from '@/stores/previouslyCheckedStore';
 import { TestResult, useTestStore } from '@/stores/testStore';
-import { motion } from 'framer-motion';
 import { LoaderIcon } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { cn } from '@/lib/utils';
 import { useQueryString } from '@/hooks/queryString';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useObserveHeight } from '@/hooks/useObserveHeight';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { motion } from 'framer-motion';
 import { LoaderIcon } from 'lucide-react';
 import { toast } from 'sonner';
 
+import { cn } from '@/lib/utils';
 import { useQueryString } from '@/hooks/queryString';
 import { useObserveHeight } from '@/hooks/useObserveHeight';
 import { Footer } from '@/components/footer';
@@ -31,6 +32,7 @@ export default function Home() {
   const [refreshIntervalTime, setRefreshIntervalTime] = useState<number>();
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
   const [secondsUntilNextRefresh, setSecondsUntilNextRefresh] = useState<number>(0);
+  const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false);
 
   const [resolvedAddresses, setResolvedAddresses] = useState<
     Record<
@@ -126,7 +128,6 @@ export default function Home() {
     }
   }, []);
 
-  const { height, ref } = useObserveHeight<HTMLFormElement>();
   return (
     <main className="flex min-h-screen flex-col">
       <Header>
@@ -145,7 +146,8 @@ export default function Home() {
       <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col items-start gap-4 px-4 pb-14 lg:mt-10 lg:flex-row">
         <div className="w-full space-y-6 md:sticky lg:top-10 lg:max-w-md">
           <SearchForm
-            formRef={ref}
+            advancedOptionsOpen={advancedOptionsOpen}
+            setAdvancedOptionsOpen={setAdvancedOptionsOpen}
             onSubmit={(data) => {
               if (data.refresh && data.refresh !== '0') {
                 setRefreshIntervalTime(parseInt(data.refresh, 10));
@@ -160,7 +162,7 @@ export default function Home() {
         </div>
         <div className="w-full flex-1">
           <h2 className=" block font-heading text-3xl lg:hidden">Results</h2>
-          <motion.div className="space-y-2" animate={{ marginBottom: height }}>
+          <div className={cn('space-y-2 lg:pb-0', advancedOptionsOpen ? 'pb-[400px]' : 'pb-24')}>
             {dnsServers.map((dnsServer) => {
               const result = resolvedAddresses[dnsServer.name];
 
@@ -188,7 +190,7 @@ export default function Home() {
                 </ResultItem>
               );
             })}
-          </motion.div>
+          </div>
         </div>
       </div>
       <Footer />

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -70,7 +70,7 @@ export function SearchForm({ onSubmit, advancedOptionsOpen, setAdvancedOptionsOp
       <div className={'flex w-full justify-center'}>
         <form
           className="
-            fixed bottom-0 w-full border border-gray-200 bg-white px-6 pb-10 pt-6 shadow-2xl lg:static lg:rounded-md lg:py-8 lg:shadow-none"
+            fixed z-10 bottom-0 w-full border border-gray-200 bg-white px-6 pb-10 pt-6 shadow-2xl lg:static lg:rounded-md lg:py-8 lg:shadow-none"
           onSubmit={form.handleSubmit(onSubmit)}
         >
           <div className="flex items-center justify-between">

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, RefObject, SetStateAction, useEffect, useState } from 'react';
 import { RecordTypes } from '@/constants/recordType';
 import { useTestStore } from '@/stores/testStore';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -18,6 +18,7 @@ import { Input } from './ui/input';
 
 interface SearchFormProps {
   onSubmit: (data: z.infer<typeof formSchema>) => void;
+  formRef: RefObject<HTMLFormElement>;
   advancedOptionsOpen: boolean;
   setAdvancedOptionsOpen: Dispatch<SetStateAction<boolean>>;
 }
@@ -33,7 +34,7 @@ const formSchema = z.object({
   recordType: z.enum(RecordTypes).default('A'),
 });
 
-export function SearchForm({ onSubmit, advancedOptionsOpen, setAdvancedOptionsOpen }: SearchFormProps) {
+export function SearchForm({ onSubmit, advancedOptionsOpen, setAdvancedOptionsOpen, formRef }: SearchFormProps) {
   const { tests, addTest } = useTestStore();
   const { setShowEditTestModal, EditTestModal } = useEditTestModal({
     onSubmit: (data) => {
@@ -69,8 +70,9 @@ export function SearchForm({ onSubmit, advancedOptionsOpen, setAdvancedOptionsOp
       ></div>
       <div className={'flex w-full justify-center'}>
         <form
+          ref={formRef}
           className="
-            fixed z-10 bottom-0 w-full border border-gray-200 bg-white px-6 pb-10 pt-6 shadow-2xl lg:static lg:rounded-md lg:py-8 lg:shadow-none"
+            fixed bottom-0 z-10 w-full border border-gray-200 bg-white px-6 pb-10 pt-6 shadow-2xl lg:static lg:rounded-md lg:py-8 lg:shadow-none"
           onSubmit={form.handleSubmit(onSubmit)}
         >
           <div className="flex items-center justify-between">

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { RefObject, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { RecordTypes } from '@/constants/recordType';
 import { useTestStore } from '@/stores/testStore';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { PlusCircleIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -18,7 +18,8 @@ import { Input } from './ui/input';
 
 interface SearchFormProps {
   onSubmit: (data: z.infer<typeof formSchema>) => void;
-  formRef: RefObject<HTMLFormElement>;
+  advancedOptionsOpen: boolean;
+  setAdvancedOptionsOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const formSchema = z.object({
@@ -32,9 +33,8 @@ const formSchema = z.object({
   recordType: z.enum(RecordTypes).default('A'),
 });
 
-export function SearchForm({ onSubmit, formRef }: SearchFormProps) {
+export function SearchForm({ onSubmit, advancedOptionsOpen, setAdvancedOptionsOpen }: SearchFormProps) {
   const { tests, addTest } = useTestStore();
-  const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false);
   const { setShowEditTestModal, EditTestModal } = useEditTestModal({
     onSubmit: (data) => {
       if (data.type === 'regex') {
@@ -45,7 +45,6 @@ export function SearchForm({ onSubmit, formRef }: SearchFormProps) {
       setShowEditTestModal(false);
     },
   });
-
   const { searchParams } = useQueryString();
   const url = searchParams.get('url') || '';
 
@@ -69,100 +68,106 @@ export function SearchForm({ onSubmit, formRef }: SearchFormProps) {
         onClick={() => setAdvancedOptionsOpen(false)}
       ></div>
       <div className={'flex w-full justify-center'}>
-        <motion.form
-          ref={formRef}
-          layout
+        <form
           className="
             fixed bottom-0 w-full border border-gray-200 bg-white px-6 pb-10 pt-6 shadow-2xl lg:static lg:rounded-md lg:py-8 lg:shadow-none"
           onSubmit={form.handleSubmit(onSubmit)}
         >
-          <motion.div layout className="flex items-center justify-between">
+          <div className="flex items-center justify-between">
             <label htmlFor="url" className="block text-sm font-medium text-gray-700">
               Your domain
             </label>
-          </motion.div>
-          <motion.div layout className="relative mt-1 flex flex-col rounded-md">
+          </div>
+          <div className="relative mt-1 flex flex-col rounded-md">
             <Input id="url" type="text" placeholder="example.com" className="shadow-sm" {...form.register('url')} />
             {form.formState.errors.url && (
               <p className="mt-2 text-xs text-red-500">{form.formState.errors.url.message}</p>
             )}
-          </motion.div>
-          <motion.div layout className="mt-4 flex justify-between">
+          </div>
+          <div className="mt-4 flex justify-between">
             <Button type="submit">Check my domain</Button>
             <Button type="button" variant="link" onClick={() => setAdvancedOptionsOpen((prev) => !prev)}>
               Advanced options
             </Button>
-          </motion.div>
+          </div>
 
           {/* Advanced options */}
-          {advancedOptionsOpen && (
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.1 }} className="mt-4">
-              <hr className="my-4 border-gray-200" />
-              <h2 className="mb-2 text-xs font-medium text-gray-700/60">Advanced options</h2>
-              <div>
-                <div className="flex items-center justify-between">
-                  <label htmlFor="refresh" className="block space-x-1 text-sm font-medium text-gray-700">
-                    <span>Refresh interval</span>
-                    <span className="text-xs text-gray-500">(leave empty to disable)</span>
-                  </label>
-                </div>
-                <div className="relative mt-1 flex rounded-md">
-                  <Input
-                    type="number"
-                    min={5}
-                    id="refresh"
-                    className="shadow-sm [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                    {...form.register('refresh')}
-                  />
-                  <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-xs text-gray-500">
-                    seconds
-                  </span>
-                </div>
-                {form.formState.errors.refresh && (
-                  <p className="mt-2 text-xs text-red-500">{form.formState.errors.refresh.message}</p>
-                )}
-              </div>
-              <div>
-                <div className="mt-4 flex items-center justify-between">
-                  <label htmlFor="recordType" className="block space-x-1 text-sm font-medium text-gray-700">
-                    <span>Record Type</span>
-                  </label>
-                </div>
-                <div className="relative mt-1 flex rounded-md shadow-sm">
-                  <select
-                    id="recordType"
-                    className="block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
-                    {...form.register('recordType')}
-                  >
-                    {RecordTypes.map((type) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              <hr className="my-4 border-gray-200" />
-              <h2 className="mb-2 text-xs font-medium text-gray-700/60">Tests</h2>
-              <motion.ul layout layoutRoot className="mt-2 space-y-2">
-                {tests.map((test) => (
-                  <TestItem key={test.id} test={test} />
-                ))}
-              </motion.ul>
-              <Button
-                type="button"
-                variant="secondary"
-                className="mt-2 w-full"
-                onClick={() => {
-                  setShowEditTestModal(true);
-                }}
+          <AnimatePresence mode={'sync'}>
+            {advancedOptionsOpen && (
+              <motion.div
+                initial={{ opacity: 0, y: -10, height: 0 }}
+                animate={{ opacity: 1, y: 0, height: 'auto' }}
+                exit={{ opacity: 0, y: -10, height: 0 }}
+                transition={{ duration: 0.1, ease: 'easeInOut' }}
+                className="mt-4"
               >
-                <PlusCircleIcon className="mr-2" size={16} />
-                New Test
-              </Button>
-            </motion.div>
-          )}
-        </motion.form>
+                <hr className="my-4 border-gray-200" />
+                <h2 className="mb-2 text-xs font-medium text-gray-700/60">Advanced options</h2>
+                <div>
+                  <div className="flex items-center justify-between">
+                    <label htmlFor="refresh" className="block space-x-1 text-sm font-medium text-gray-700">
+                      <span>Refresh interval</span>
+                      <span className="text-xs text-gray-500">(leave empty to disable)</span>
+                    </label>
+                  </div>
+                  <div className="relative mt-1 flex rounded-md">
+                    <Input
+                      type="number"
+                      min={5}
+                      id="refresh"
+                      className="shadow-sm [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      {...form.register('refresh')}
+                    />
+                    <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-xs text-gray-500">
+                      seconds
+                    </span>
+                  </div>
+                  {form.formState.errors.refresh && (
+                    <p className="mt-2 text-xs text-red-500">{form.formState.errors.refresh.message}</p>
+                  )}
+                </div>
+                <div>
+                  <div className="mt-4 flex items-center justify-between">
+                    <label htmlFor="recordType" className="block space-x-1 text-sm font-medium text-gray-700">
+                      <span>Record Type</span>
+                    </label>
+                  </div>
+                  <div className="relative mt-1 flex rounded-md shadow-sm">
+                    <select
+                      id="recordType"
+                      className="block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                      {...form.register('recordType')}
+                    >
+                      {RecordTypes.map((type) => (
+                        <option key={type} value={type}>
+                          {type}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <hr className="my-4 border-gray-200" />
+                <h2 className="mb-2 text-xs font-medium text-gray-700/60">Tests</h2>
+                <ul className="mt-2 space-y-2">
+                  {tests.map((test) => (
+                    <TestItem key={test.id} test={test} />
+                  ))}
+                </ul>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-2 w-full"
+                  onClick={() => {
+                    setShowEditTestModal(true);
+                  }}
+                >
+                  <PlusCircleIcon className="mr-2" size={16} />
+                  New Test
+                </Button>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </form>
       </div>
     </>
   );

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dispatch, RefObject, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, RefObject, SetStateAction, useEffect } from 'react';
 import { RecordTypes } from '@/constants/recordType';
 import { useTestStore } from '@/stores/testStore';
 import { zodResolver } from '@hookform/resolvers/zod';


### PR DESCRIPTION
This PR fixes both https://github.com/l-mbert/dns-checker/issues/7 and https://github.com/l-mbert/dns-checker/issues/8 where the UI would do some funny stuff when an error message showed up / layout shifts occured in general.

- Removed layout animations and animated height and opacity instead
- Moved the "isAdvancedOpen" state to the page component to manage the padding better
- Added a z-index to the drawer to prevent the loading spinners from overlaying it